### PR TITLE
Improve dev and deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,177 +1,182 @@
 # Freezing Saddles Docker Compose Files
 
-This project is for deploying the Freezing Saddles application, using [Docker Compose](https://docs.docker.com/compose/).
+This project is for deploying the Freezing Saddles application for either development or production.
 
-## Deploy
+Before you get started, we assume you have already installed [Docker](https://docker.com) and [Docker Compose](https://docs.docker.com/compose/).
 
-This repository can be used to deploy the Freezing Saddles application for production.  Before you get started, we assume you
-have already installed [Docker](http://docker.com) and [Docker Compose](https://docs.docker.com/compose/).
 
-### Clone Repo
+## 1. Development
 
-Start by cloning this repository on your production server.  For simplicity, we are going to assume you are performing these tasks
-as root -- or a user that is part of `docker` group and can write to these direcotries, etc.
+You can use the `docker-compose.dev.yml` file, in conjunction with the main `docker-compose.yml` file,
+to spin up services that might be needed during development, but not production.
+
+The `docker-compose.yml` file does not define a service for the database, but the `docker-compose.dev.yml` file does.
+
+### 1.1 Clone Repository
+
+Start by cloning this repository on your development workstation.
 
 For example:
 
 ```
-sudo git clone https://github.com/freezingsaddles/freezing-compose /opt/compose
+git clone https://github.com/freezingsaddles/freezing-compose
 ```
 
 Now you can confirm that docker-compose is working correctly by changing to that directory and executing `docker-compose` commands.
 
 ```
-cd /opt/Compose
+cd freezing-compose
 docker-compose ps
 ```
 
-You should see lots of warnings about undefined configuration variables.  Good! -- We'll get to that next.
+You should see lots of warnings about undefined configuration variables. Good! We will get to that next.
 
-### Configure
+### 1.2 Configure Environment Variables for `docker-compose` in `.env` file
 
 Copy the `example.env` file to a file named `.env`.  This is where `docker-compose` will look for environment variables.
-
-Here is an annotated example of production configuration:
-
-```shell
-# FQDNs and SSL
-# -------------
-#
-# These domain names are used for letsencrypt and nginx reverse proxies.  You need to actually
-# own these domains and have them setup to point to your server public IP address.
-
-# The FREEZING_NQ_FQDN is the domain name that we configure with Strava to act as a webhook for the application.
-# See https://developers.strava.com/docs/webhooks/ for guide on configuring webhooks.
-FREEZING_NQ_FQDN=hook.freezingsaddles.org
-
-# This is the main URL for the website. You likely want to include www. prefix here.
-FREEZING_WEB_FQDN=freezingsaddles.org,www.freezingsaddles.org
-
-# You will also need to set an email address to use for the letsencrypt (SSL cert) email.
-LETSENCRYPT_EMAIL=admin@example.com
-
-# Logging Settings
-# ----------------
-
-# If you have a datadog account, put the API and APP keys here.
-DATADOG_API_KEY=deadbeef
-DATADOG_APP_KEY=deadbeef
-
-# Set the endpoint to use for syslog.  This examples shows using papertrail:
-SYSLOG_ENDPOINT=syslog://logs6.papertrailapp.com:<MY_PORT_NUM>
-
-# App Settings
-# ------------
-
-# Display stack traces, etc.
-DEBUG=true
-
-# This is used for Flask session keying.  Set it to something unique, for example:
-#  python -c 'import uuid; print(uuid.uuid4())'
-SECRET_KEY=deadbeef
-
-# The URL to the database.
-# (Currently this is MySQL still)
-SQLALCHEMY_URL=mysql+pymysql://freezing:<password>@dbhostname/freezing?charset=utf8mb4&binary_prefix=true
-
-# The ID/Key for the Strava app.
-STRAVA_CLIENT_ID=12345
-STRAVA_CLIENT_SECRET=deadbeef
-
-# The verify token is used for webhook registration
-STRAVA_VERIFY_TOKEN=FREEZE
-
-# And you need a key for getting the weather data too.
-WUNDERGROUND_API_KEY=deadbeef
-
-# A comma-separated list of Strava team IDs.
-TEAMS=12345,54321,98765
-
-# The start date for the competition.  For Freezing Saddles this is traditionally midnight Jan 1.
-# Important: include the time zone offset here for where the competition is based, or it'll assume GMT.
-START_DATE=2018-01-01T00:00:00-05:00
-
-# When does the competition end?  (This can be an exact time; API will stop fetching after this time.)
-# Again, include the time zone here or it'll assume GMT.
-END_DATE=2018-03-20T00:01:00-04:00
-
-# Python Time zone for competition days.
-# See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-TIMEZONE=America/New_Yorkk
 ```
+cp sample-env .env
+# edit the environment
+vi .env
 
-These environment variables will be passed in to the various services that need them
-(look through them `docker-compose.yml` file to see how that works).
+See [sample.env](sample.env) for a complete annotated example of a docker-compose `.env` file.
 
-## Develop
+These environment variables will be passed in to the various services that need them. Look through them the `docker-compose.yml` file to see how that works.
 
-You can also use the `docker-compose.dev.yml` file, in conjunction with the main `docker-compose.yml` file,
-to spin up services that might be needed during development, but not production.
+For development, you won't need all the values, so don't worry about needing to set up a Strava app or Datadog account before you begin developing.
 
-For example, the `docker-compose.yml` file does not define a service for the database, but the `docker-compose.dev.yml` file does.
+### 1.3 Configure and Start MySQL Only
 
-### Common Steps
+We recommend that for development, you run MySQL through Docker and `docker-compose`. To start up 
+start up MySQL using `docker-compose`, follow these steps:
 
-To begin, you'll need to clone the repo, just as we did for production install.
-
-Also, you'll want to create a `.env` file, as above.  You won't need all the values, so don't worry about needing to set up
-a Strava app or Datadog account, etc.
-
-### Part 1: Starting Just MySQL
-
-Here is an example of starting up MySQL using docker-compose and then importing a snapshot of the production data.
-
-First, edit your `.env` to specify some MySQL parameters:
+1. Make sure that you have edited your `.env` file to have different passwords for MYSQL_ROOT_PASSWORD and MYSQL_PASSWORD
+2. Create the named volume Docker will use for the MySQL database
+3. Start the MySQL container
 
 ```shell
-# The root password, unsurprisngly:
-MYSQL_ROOT_PASSWORD=somepassword
+# Edit your .env file and pick new passwords
+vi .env
 
-# This is the database that will be created:
-MYSQL_DATABASE=freezing
-# This is the user/password with access to the app database:
-MYSQL_USER=freezing
-MYSQL_PASSWORD=anotherpassword
-```
-
-Then when you start up the container, those values will be used.
-
-```shell
-# If you have not already, you first need to create the named volumes
+# If you have not already, you first need to create these named volumes:
 docker volume create --name=freezing-data
-docker volume create --name=beanstalkd-data
 
 # Then you can start MySQL container
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d mysql
+
+# MySQL will take up to 60 seconds to become ready, you can monitor 
+docker logs freezing-mysql 2>&1 | tail
 ```
 
-Hint: if you ever want to blow away your MySQL db.  Just remove the container and volume and re "up" it:
+The output from the `docker logs` command will look something like this once the server is up and running:
+
+```
+2019-12-01 04:04:23 1 [Note] RSA public key file not found: /var/lib/mysql//public_key.pem. Some authentication plugins will not work.
+2019-12-01 04:04:23 1 [Note] Server hostname (bind-address): '*'; port: 3306
+2019-12-01 04:04:23 1 [Note] IPv6 is available.
+2019-12-01 04:04:23 1 [Note]   - '::' resolves to '::';
+2019-12-01 04:04:23 1 [Note] Server socket created on IP: '::'.
+2019-12-01 04:04:23 1 [Warning] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2019-12-01 04:04:23 1 [Warning] 'proxies_priv' entry '@ root@freezing-mysql' ignored in --skip-name-resolve mode.
+2019-12-01 04:04:23 1 [Note] Event Scheduler: Loaded 0 events
+2019-12-01 04:04:23 1 [Note] mysqld: ready for connections.
+Version: '5.6.46'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server (GPL)
+```
+
+
+### 1.3 Connecting to the database
+You can also use Docker to connect to the database. The command required is long and tedious, so create a shell alias for it:
+```
+alias mysql-freezing='docker run -t -i --rm --network=host mysql:5.6 mysql --host=127.0.0.1 --port=3306 --user=freezing --password=please-change-me-as-this-is-a-default --database=freezing --default-character-set=utf8mb4'
+mysql-freezing
+```
+
+Once connected, you can issue MySQL commands and queries:
+```
+$ mysql-freezing
+Warning: Using a password on the command line interface can be insecure.
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 6
+Server version: 5.6.46 MySQL Community Server (GPL)
+
+Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql> status
+--------------
+mysql  Ver 14.14 Distrib 5.6.46, for Linux (x86_64) using  EditLine wrapper
+
+Connection id:		6
+Current database:	freezing
+Current user:		freezing@172.19.0.1
+SSL:			Not in use
+Current pager:		stdout
+Using outfile:		''
+Using delimiter:	;
+Server version:		5.6.46 MySQL Community Server (GPL)
+Protocol version:	10
+Connection:		127.0.0.1 via TCP/IP
+Server characterset:	latin1
+Db     characterset:	latin1
+Client characterset:	utf8mb4
+Conn.  characterset:	utf8mb4
+TCP port:		3306
+Uptime:			7 min 55 sec
+
+Threads: 1  Questions: 7  Slow queries: 0  Opens: 67  Flush tables: 1  Open tables: 60  Queries per second avg: 0.014
+--------------
+
+mysql> show databases;
++--------------------+
+| Database           |
++--------------------+
+| information_schema |
+| freezing           |
++--------------------+
+2 rows in set (0.01 sec)
+
+mysql> quit
+Bye
+```
+
+### 1.4 Loading in Data (optional)
+
+If you have a MySQL dump (e.g. of the production database), you can load it into a fresh database like this:
+```shell
+$ mysql -h 127.0.0.1 -u root -p freezing < freezing-2019-03-20.dump
+Enter password: <type in the root password you configured above>
+...
+$ # Or if you have configured the mysql-freezing alias:
+$ mysql-freezing < freezing-2019-03-20.sql
+```
+
+Note: it is important to specify the `127.0.0.1` host, since otherwise mysql assumes a server listening on a local unix socket. MySQL in the container is only listening on TCP.
+
+If you don't have a dump file, the first time the `freezing-web` container is run it will populate the schema and baseline tables using the South database migration toolkit.
+
+### 1.5 Recreating the MySQL database
+If you ever want to destroy and recreate your MySQL database, just remove the container and volume and re "up" it:
 
 ```shell
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml stop mysql
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml rm mysql
 
-docker volume rm freezing-data
-docker volume create --name=freezing-data
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d mysql
+docker volume rm freezing-data && \
+    docker volume create --name=freezing-data && \
+    docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d mysql
 ```
 
-#### Loading in Data
 
-If you have a MySQL dump (e.g. of the production database), you can load it into a fresh database like this:
-```shell
-mysql -h 127.0.0.1 -u root -p freezing < freezing-snap.dump
-Enter password: <type in the root password you configured above>
-```
-
-Note: it is important to specify the `127.0.0.1` host, since otherwise mysql assumes a server listening on local
-unix socket.  MySQL in the container is only listening on TCP.
-
-### Part 2: Running other Containers Too
+### 1.6 Running `freezing-web` and Other Containers via `docker-compose`
 
 Now that MySQL is running, you can also start up the freezing-web container to actually have the website running locally.
 
-(I recommend not bothering with nginx, letsencrypt, etc. as those expect real domain names, etc.)
+(For local development, you don't need to bother with running nginx, letsencrypt, etc, as those expect real domain names and actual account credentials.)
 
 The website expects some minimum configuration to be specified, so you may need to check your `.env` file:
 ```shell
@@ -181,9 +186,10 @@ SECRET_KEY=deadbeef
 
 # For the SA URL, you need to use the user & password you configured for your app db above.
 # The host should be 'mysql.container' which will be resolved by docker to the myslq container's IP address
-SQLALCHEMY_URL=mysql+pymysql://freezing:anotherpassword@mysql.container/freezing?charset=utf8mb4&binary_prefix=true
+SQLALCHEMY_URL=mysql+pymysql://freezing:please-change-me-as-this-is-a-default@mysql.container/freezing?charset=utf8mb4&binary_prefix=true
 
-# Some of the website reports, etc. expects the start date and end date and teams to be configured.
+# Some of the website reports expect the start date and end date and teams to be configured.
+
 ```
 
 Now you can start up the `freezing-web` container!
@@ -195,3 +201,53 @@ docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d freezing-we
 Note that if you want to do website development, it's easier to just set up a python virtual environment instead.
 
 See the README for [freezing-web](https://github.com/freezingsaddles/freezing-web) for those instructions.
+
+## 2. Deploy to Production
+
+This repository can be used to deploy the Freezing Saddles application for production.  Before you get started, we assume you
+have already installed [Docker](http://docker.com) and [Docker Compose](https://docs.docker.com/compose/).
+
+
+```shell
+# If you have not already, you first need to create these named volumes:
+docker volume create --name=freezing-data
+docker volume create --name=beanstalkd-data
+```
+
+```
+
+### 2.1 Clone Repository
+
+Clone the repository this repository onto a server that runs Docker and `docker-compose`. [freezingsaddles.org](https://freezingsaddles.org/] has run on CoreOS since 2018 but works but any operating system distribution that has Docker support will probably do.
+
+For example:
+
+```
+sudo git clone https://github.com/freezingsaddles/freezing-compose /opt/compose
+# Change ownership back to your regular user so you can update it
+sudo chown -R $(id -u):$(id -g) /opt/compose
+```
+
+### 2.2 Configure Environment
+```
+# Create and edit the .env file, filling it in completely with real values
+cd /opt/compose
+cp example.env .env
+vi .env
+
+# Verify Docker compose is working
+docker-compose ps
+```
+
+### 2.3 Run Containers
+```
+cd /opt/compose
+docker-compose up -d
+# wait a minute, then verify that the containers are working
+sleep 60
+docker-compose ps
+```
+
+If any containers are not started, troubleshoot with `docker ps` and `docker logs container-name`. You might need to tweak the configuration multiple times before all containers come up cleanly. Restart the containers after tweaking the `.env` file each time with `docker-compose up -d` until things work.
+
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,9 @@ services:
     volumes:
       - freezing-data:/var/lib/mysql
       #- ./docker/db/sql-scripts:/sql
+    # Run mysqld with ideal UTF-8 character set defaults
+    # Thanks Javier Arias & Stack Overflow https://stackoverflow.com/a/50529359
+    command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-fr33z3}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-freezing}

--- a/example.env
+++ b/example.env
@@ -1,52 +1,40 @@
-# FQDNs and SSL
-# -------------
+# MySQL Settings - for freezing-mysql container
+# ---------------------------------------------
 #
-# These domain names are used for letsencrypt and nginx reverse proxies.  You need to actually
-# own these domains and have them setup to point to your server public IP address.
+# These are needed by the mysql container defined in docker-compose.dev.yml,
+# but not all are needed in production if you use an external MySQL server,
+# which is the recommended configuration.
+#
+# The MySQL root password (not needed for a setup where MySQL is external)
+MYSQL_ROOT_PASSWORD=terrible-root-password-which-should-be-changed
 
-# The FREEZING_NQ_FQDN is the domain name that we configure with Strava to act as a webhook for the application.
-# See https://developers.strava.com/docs/webhooks/ for guide on configuring webhooks.
-FREEZING_NQ_FQDN=hook.freezingsaddles.org
+# This is the database that will be created:
+MYSQL_DATABASE=freezing
+# This is the user/password with access to the app database:
+MYSQL_USER=freezing
+MYSQL_PASSWORD=please-change-me-as-this-is-a-default
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
 
-# This is the main URL for the website. You likely want to include www. prefix here.
-FREEZING_WEB_FQDN=freezingsaddles.org,www.freezingsaddles.org
 
-# You will also need to set an email address to use for the letsencrypt (SSL cert) email.
-LETSENCRYPT_EMAIL=admin@example.com
+# Web Application Settings - for freezing-web container
+# -----------------------------------------------------
 
-# Logging Settings
-# ----------------
+# Title for the competition
+COMPETITION_TITLE=Freezing Saddles
 
-# If you have a datadog account, put the API and APP keys here.
-DATADOG_API_KEY=deadbeef
-DATADOG_APP_KEY=deadbeef
-
-# Set the endpoint to use for syslog.  This examples shows using papertrail:
-SYSLOG_ENDPOINT=syslog://logs6.papertrailapp.com:<MY_PORT_NUM>
-
-# App Settings
-# ------------
-
-# Display stack traces, etc.
-DEBUG=true
-
-# This is used for Flask session keying.  Set it to something unique, for example:
+# Flask session keying secret key. Set it to something unique, for example:
 #  python -c 'import uuid; print(uuid.uuid4())'
 SECRET_KEY=deadbeef
 
 # The URL to the database.
-# (Currently this is MySQL still)
-SQLALCHEMY_URL=mysql+pymysql://freezing:<password>@dbhostname/freezing?charset=utf8mb4&binary_prefix=true
+# If you are running MySQL through Docker,
+# substitute the values above into the URL below.
+SQLALCHEMY_URL=mysql+pymysql://freezing:please-change-me-as-this-is-a-default@mysql.container:3306/freezing?charset=utf8mb4&binary_prefix=true
 
-# The ID/Key for the Strava app.
-STRAVA_CLIENT_ID=12345
-STRAVA_CLIENT_SECRET=deadbeef
-
-# The verify token is used for webhook registration
-STRAVA_VERIFY_TOKEN=FREEZE
-
-# And you need a key for getting the weather data too.
-WUNDERGROUND_API_KEY=deadbeef
+# If you run MySQL externally, use this instead, but substitute the real 
+# values of username, password, host, port, and database name into the URL.
+#SQLALCHEMY_URL=mysql+pymysql://freezing:SUperC0ld-fake-password@mysql.example.com:3306/freezing?charset=utf8mb4&binary_prefix=true
 
 # A comma-separated list of Strava team IDs.
 TEAMS=12345,54321,98765
@@ -59,17 +47,89 @@ OBSERVER_TEAMS=23456
 # The main competition team ID that everyone participating joins
 MAIN_TEAM=23456
 
-# The start date for the competition.  For Freezing Saddles this is traditionally midnight Jan 1.
-# Important: include the time zone offset here for where the competition is based, or it'll assume GMT.
-START_DATE=2018-01-01T00:00:00-05:00
-
-# When does the competition end?  (This can be an exact time; API will stop fetching after this time.)
-# Again, include the time zone here or it'll assume GMT.
-END_DATE=2018-03-20T00:01:00-04:00
-
-# Python Time zone for competition days. 
+# Python Time zone for competition days. The web site uses this to display times.
 # See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 TIMEZONE=America/New_York
 
-# Competition title
-COMPETITION_TITLE=Freezing Saddles
+# The start date for the competition.
+#
+# This should be an exact time; the freezing-sync code will only start recording 
+# rides begun on after the precise timestamp of the start date.
+#
+# For Freezing Saddles this is traditionally Midnight on January 1st.
+#
+# Important: Include the time zone offset here for where the competition
+#            is based, or it will assume UTC.
+START_DATE=2019-01-01T00:00:00-05:00
+
+# The end date for the competition.
+#
+# This should be an exact time; the freezing-sync code will stop recording 
+# rides completed after the precise timestamp of the end date.
+#
+# For Freezing Saddles this is traditionally Midnight on the first full day of Spring.
+# That means that some period less than 24 hours of the competiton is ridden
+# during springtime.
+#
+# Important: Include the time zone offset here for where the competition
+#            is based, or it will assume UTC.
+END_DATE=2019-03-20T00:00:00-04:00
+
+# Display stack traces, etc. 
+# Set this to false for production, but set it to true to for local development.
+DEBUG=false
+
+
+# External Integrations - for freezing-web and freezing-sync containers
+# ---------------------
+# You do not have to set any of these up for local development of
+# just the freezing-web project. 
+# However at least the Strava credentials are required for local development
+# of freezing-sync. 
+
+# The ID/Key for the Strava app.
+STRAVA_CLIENT_ID=12345
+STRAVA_CLIENT_SECRET=deadbeef
+
+# The verify token is used for webhook registration
+STRAVA_VERIFY_TOKEN=FREEZE
+
+# The API key for Weather Underground, to retrieve geo-tagged time series weather data.
+# FIXME: Weather Underground API is dead, but we have not yet fixed
+#        the software to compensate.
+#        See https://github.com/freezingsaddles/freezing-sync/issues/5
+WUNDERGROUND_API_KEY=deadbeef
+
+# Optional: If you have a datadog account, put the API and APP keys here.
+DATADOG_API_KEY=deadbeef
+DATADOG_APP_KEY=deadbeef
+
+# Optional: Set the endpoint to use for syslog. 
+# This example shows using papertrail:
+SYSLOG_ENDPOINT=syslog://logs6.papertrailapp.com:999999
+
+# FQDNs and SSL - for letsencrypt and nginx containers
+# ----------------------------------------------------
+# This are of setup is not required for local development, but it is
+# required for production deployments.
+#
+# These domain names are used for letsencrypt and nginx reverse proxies.
+#
+# You must actually control these domains.
+#
+# Before configuring this, please configure A or CNAME records
+# that point to the public IP address of your production server.
+
+# The FREEZING_NQ_FQDN is the domain name that we configure with Strava 
+# to act as a webhook for the application.
+#
+# See https://developers.strava.com/docs/webhooks/ for their developer guide.
+FREEZING_NQ_FQDN=hook.example.com
+
+# This is the main URL for the website.
+# You likely want to include www. prefix here in addition to the bare domain.
+FREEZING_WEB_FQDN=example.com,www.example.com
+
+# You must set an email address to use for the letsencrypt (SSL cert) email.
+LETSENCRYPT_EMAIL=admin@example.com
+


### PR DESCRIPTION
Improve both local dev and production deploy docs

After getting @spfrantz running with a `freezing-compose` driven local MySQL server, it was clear that the documentation could use some work. I fixed both the `README.md` and `example.env` file to be way more clear about what order you have to do things to make it work.

I also further tweaked the MySQL setup to ensure that it would use UTF-8 instead of the latin1 character set.

* Add shell aliases
* Add link to future issue about MySQL in prod in a container
* Fix output to show utf-8
* Add more example output
 
