### PR TITLE
Add WordPress registration site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*
 /sync-data
+/wordpress

--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ start up MySQL using `docker-compose`, follow these steps:
 vi .env
 
 # If you have not already, you first need to create these named volumes:
+
+```
 docker volume create --name=freezing-data
 docker volume create --name=beanstalkd-data
+```
 
 # Then you can start MySQL container
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d mysql
@@ -338,6 +341,7 @@ Create the persistent volumes needed for production:
 ```shell
 docker volume create --name=freezing-data
 docker volume create --name=beanstalkd-data
+docker volume create --name=wordpress-data
 ```
 
 ### 2.3 Configure MySQL production server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ volumes:
     external: true
   beanstalkd-data:
     external: true
-  wordpress-data:
-    external: true
   nginx-config:
   nginx-certs:
   nginx-vhosts:
@@ -226,11 +224,11 @@ services:
       options:
         max-file: "2"
         max-size: 10m
-  register:
+  wordpress:
     image: wordpress:5.8.2
     container_name: wordpress
     volumes:
-      - wordpress-data:/var/www/html
+      - ./wordpress:/var/www/html
     restart: always
     environment:
       VIRTUAL_HOST: ${FREEZING_REGISTER_FQDN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ volumes:
     external: true
   beanstalkd-data:
     external: true
+  wordpress-data:
+    external: true
   nginx-config:
   nginx-certs:
   nginx-vhosts:
@@ -218,6 +220,26 @@ services:
       END_DATE: ${END_DATE}
       TIMEZONE: ${TIMEZONE:-America/New_York}
       COMPETITION_TITLE: ${COMPETITION_TITLE}
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-file: "2"
+        max-size: 10m
+  register:
+    image: wordpress:5.8.2
+    container_name: wordpress
+    volumes:
+      - wordpress-data:/var/www/html
+    restart: always
+    environment:
+      VIRTUAL_HOST: ${FREEZING_REGISTER_FQDN}
+      LETSENCRYPT_HOST: ${FREEZING_REGISTER_FQDN}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
+      WORDPRESS_DB_HOST: ${WORDPRESS_DB_HOST}
+      WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD}
+      WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME}
     restart: unless-stopped
     logging:
       driver: json-file

--- a/example.env
+++ b/example.env
@@ -138,6 +138,9 @@ SYSLOG_ENDPOINT=syslog://logs6.papertrailapp.com:999999
 # See https://developers.strava.com/docs/webhooks/ for their developer guide.
 FREEZING_NQ_FQDN=hook.example.com
 
+# The FREEZING_REGISTER_FQDN is the domain name that we configure for Wordpress for the registration site.
+FREEZING_REGISTER_FQDN=register.example.com
+
 # This is the main URL for the website.
 # You likely want to include www. prefix here in addition to the bare domain.
 FREEZING_WEB_FQDN=example.com,www.example.com
@@ -145,3 +148,8 @@ FREEZING_WEB_FQDN=example.com,www.example.com
 # You must set an email address to use for the letsencrypt (SSL cert) email.
 LETSENCRYPT_EMAIL=admin@example.com
 
+# WordPress settings for registration site
+WORDPRESS_DB_HOST=mysql.example.com:3306
+WORDPRESS_DB_USER=wordpress
+WORDPRESS_DB_PASSWORD=not-the-real-password
+WORDPRESS_DB_NAME=wordpress


### PR DESCRIPTION
Resolves #16 

This has the Docker Compose machinery needed to resolve this, adapted from https://docs.docker.com/samples/wordpress/ and using the https://hub.docker.com/_/wordpress official image.

I had to add VIRTUAL_HOST, LETSECNRYPT_HOST, and LETSENCRYPT_EMAIL variables for the new Wordpress container to get the NGINX and LetsEncrypt machinery wired up correctly.

There's still the matter of migrating the site from http://s94971567.onlinehome.us though. That may require WordPress plugin work or lower-level migration if that does not work.