### PR TITLE
Changes needed for Rocky Linux 8+

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,7 +32,6 @@ services:
     restart: unless-stopped
     image: mysql:5.7
     container_name: freezing-mysql
-    hostname: freezing-mysql
     ports:
       - "3306:3306"
     volumes:
@@ -41,6 +40,8 @@ services:
     # Thanks Javier Arias & Stack Overflow https://stackoverflow.com/a/50529359
     command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']  # yamllint disable-line rule:line-length
     environment:
+      MYSQL_HOST: ${MYSQL_HOST:-mysql}
+      MYSQL_PORT: ${MYSQL_PORT:-3306}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-terrible-root-password-which-should-be-changed}  # yamllint disable-line rule:line-length
       MYSQL_DATABASE: ${MYSQL_DATABASE:-freezing}
       MYSQL_USER: ${MYSQL_USER:-freezing}
@@ -69,13 +70,26 @@ services:
   freezing-web:
     image: ${FREEZING_WEB_IMAGE:-freezingsaddles/freezing-web:latest}
     restart: unless-stopped
-    ports:
-      - 8000:8000
-    environment:
-      BEANSTALKD_HOST: ${BEANSTALKD_HOST:-beanstalkd}
-      BEANSTALKD_PORT: ${BEANSTALKD_PORT:-11300}
-      MYSQL_HOST: ${MYSQL_HOST:-mysql}
-      MYSQL_PORT: ${MYSQL_HOST:-3306}
     depends_on:
       - beanstalkd
       - mysql
+    ports:
+      - 8000:8000
+    environment:
+      ENVIRONMENT: ${ENVIRONMENT}
+      VIRTUAL_HOST: ${FREEZING_WEB_FQDN}
+      LETSENCRYPT_HOST: ${FREEZING_WEB_FQDN}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
+      SECRET_KEY: ${SECRET_KEY}
+      DEBUG: ${DEBUG}
+      SQLALCHEMY_URL: ${SQLALCHEMY_URL}
+      STRAVA_CLIENT_ID: ${STRAVA_CLIENT_ID}
+      STRAVA_CLIENT_SECRET: ${STRAVA_CLIENT_SECRET}
+      TEAMS: ${TEAMS}
+      OBSERVER_TEAMS: ${OBSERVER_TEAMS}
+      MAIN_TEAM: ${MAIN_TEAM}
+      START_DATE: ${START_DATE}
+      END_DATE: ${END_DATE}
+      TIMEZONE: ${TIMEZONE:-America/New_York}
+      COMPETITION_TITLE: ${COMPETITION_TITLE}
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,19 +51,31 @@ services:
   freezing-sync:
     image: ${FREEZING_SYNC_IMAGE:-freezingsaddles/freezing-sync:latest}
     restart: unless-stopped
-    links:
-      - beanstalkd:beanstalkd.container
-      - mysql:mysql.container
+    environment:
+      BEANSTALKD_HOST: ${BEANSTALKD_HOST:-beanstalkd}
+      BEANSTALKD_PORT: ${BEANSTALKD_PORT:-11300}
+      MYSQL_HOST: ${MYSQL_HOST:-mysql}
+      MYSQL_PORT: ${MYSQL_HOST:-3306}
+    depends_on:
+      - beanstalkd
+      - mysql
 
   freezing-nq:
     image: ${FREEZING_NQ_IMAGE:-freezingsaddles/freezing-nq:latest}
     restart: unless-stopped
+    depends_on:
+      - beanstalkd
 
   freezing-web:
     image: ${FREEZING_WEB_IMAGE:-freezingsaddles/freezing-web:latest}
     restart: unless-stopped
     ports:
       - 8000:8000
-    links:
-      - beanstalkd:beanstalkd.container
-      - mysql:mysql.container
+    environment:
+      BEANSTALKD_HOST: ${BEANSTALKD_HOST:-beanstalkd}
+      BEANSTALKD_PORT: ${BEANSTALKD_PORT:-11300}
+      MYSQL_HOST: ${MYSQL_HOST:-mysql}
+      MYSQL_PORT: ${MYSQL_HOST:-3306}
+    depends_on:
+      - beanstalkd
+      - mysql

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -92,4 +92,3 @@ services:
       END_DATE: ${END_DATE}
       TIMEZONE: ${TIMEZONE:-America/New_York}
       COMPETITION_TITLE: ${COMPETITION_TITLE}
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,14 +142,14 @@ services:
     image: freezingsaddles/freezing-sync:${FREEZING_SYNC_TAG:-latest}
     hostname: freezing-sync
     container_name: freezing-sync
-    links:
-      - beanstalkd:beanstalkd.container
-      - datadog:datadog.container
+    depends_on:
+      - beanstalkd
+      - datadog
     environment:
       ENVIRONMENT: ${ENVIRONMENT}
       DEBUG: ${DEBUG}
-      BEANSTALKD_HOST: beanstalkd.container
-      BEANSTALKD_PORT: 11300
+      BEANSTALKD_HOST: ${BEANSTALKD_HOST:-beanstalkd}
+      BEANSTALKD_PORT: ${BEANSTALKD_PORT:-11300}
       SQLALCHEMY_URL: ${SQLALCHEMY_URL}
       STRAVA_CLIENT_ID: ${STRAVA_CLIENT_ID}
       STRAVA_CLIENT_SECRET: ${STRAVA_CLIENT_SECRET}
@@ -159,6 +159,8 @@ services:
       MAIN_TEAM: ${MAIN_TEAM}
       START_DATE: ${START_DATE}
       END_DATE: ${END_DATE}
+      DATADOG_HOST: ${DATADOG_HOST:-datadog}
+      DATADOG_PORT: ${DATADOG_PORT:-8125}
       DATADOG_API_KEY: ${DATADOG_API_KEY}
       DATADOG_APP_KEY: ${DATADOG_APP_KEY}
       TIMEZONE: ${TIMEZONE:-America/New_York}
@@ -175,16 +177,14 @@ services:
     image: freezingsaddles/freezing-nq:latest
     hostname: freezing-nq
     container_name: freezing-nq
-    links:
-      - beanstalkd:beanstalkd.container
     environment:
       ENVIRONMENT: ${ENVIRONMENT}
       VIRTUAL_HOST: ${FREEZING_NQ_FQDN}
       LETSENCRYPT_HOST: ${FREEZING_NQ_FQDN}
       LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
       DEBUG: ${DEBUG}
-      BEANSTALKD_HOST: beanstalkd.container
-      BEANSTALKD_PORT: 11300
+      BEANSTALKD_HOST: ${BEANSTALKD_HOST:-beanstalkd}
+      BEANSTALKD_PORT: ${BEANSTALKD_PORT:-11300}
       STRAVA_VERIFY_TOKEN: ${STRAVA_VERIFY_TOKEN}
     restart: unless-stopped
     logging:
@@ -192,13 +192,15 @@ services:
       options:
         max-file: "2"
         max-size: 10m
+    depends_on:
+      - beanstalkd
 
   freezing-web:
     image: freezingsaddles/freezing-web:${FREEZING_WEB_TAG:-latest}
     hostname: freezing-web
     container_name: freezing-web
-    links:
-      - beanstalkd:beanstalkd.container
+    depends_on:
+      - beanstalkd
     environment:
       ENVIRONMENT: ${ENVIRONMENT}
       VIRTUAL_HOST: ${FREEZING_WEB_FQDN}
@@ -222,6 +224,7 @@ services:
       options:
         max-file: "2"
         max-size: 10m
+
   wordpress:
     image: wordpress:5.8.2
     container_name: wordpress

--- a/example.env
+++ b/example.env
@@ -42,7 +42,7 @@ SECRET_KEY=deadbeef
 # The URL to the database.
 # If you are running MySQL through Docker,
 # substitute the values above into the URL below.
-SQLALCHEMY_URL=mysql+pymysql://freezing:please-change-me-as-this-is-a-default@mysql.container:3306/freezing?charset=utf8mb4&binary_prefix=true
+SQLALCHEMY_URL=mysql+pymysql://freezing:please-change-me-as-this-is-a-default@mysql:3306/freezing?charset=utf8mb4&binary_prefix=true
 
 # If you run MySQL externally, use this instead, but substitute the real 
 # values of username, password, host, port, and database name into the URL.


### PR DESCRIPTION
Tested backward compatible with CentOS 7

Removed the .container suffix, links with that stopped working when we upgraded our host to Rocky Linux 8 with docker-ce 3:26.1.3-1.el8, which was unexpected. Folks will likely need to update their localdev `.env` files with the `SQLALCHEMY_URL`  that has just `mysql` instead of `mysql.container` as the host name.