### PR TITLE
Fix sysstat collection timer

### DIFF
--- a/bin/provision-server.sh
+++ b/bin/provision-server.sh
@@ -138,9 +138,10 @@ firewall-cmd --reload
 # Start services
 services='
 dnf-automatic.timer
-firewalld
-postfix
 docker
+firewalld
+sysstat-collect.timer
+postfix
 '
 for svc in $services; do
 	systemctl enable "$svc"


### PR DESCRIPTION
We old timers like to use `sar` and without `sysstat` running on a schedule it doesn't show any statistics.