### PR TITLE
Just use the awslogs driver to send to CloudWatch

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,8 +12,8 @@ services:
     logging: &json-logging
       driver: json-file
       options:
-         max-file: "2"
-         max-size: 10m
+        max-file: "2"
+        max-size: 10m
 
   beanstalkd:
     restart: unless-stopped

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,38 +9,27 @@ services:
 
   datadog:
     restart: unless-stopped
-    logging:
+    logging: &json-logging
       driver: json-file
-        max-file: "2"
-        max-size: 10m
+      options:
+         max-file: "2"
+         max-size: 10m
 
   beanstalkd:
     restart: unless-stopped
-    logging:
-      driver: json-file
-        max-file: "2"
-        max-size: 10m
+    logging: *json-logging
 
   nginx:
     restart: unless-stopped
-    logging:
-      driver: json-file
-        max-file: "2"
-        max-size: 10m
+    logging: *json-logging
 
   nginx-letsencrypt:
     restart: unless-stopped
-    logging:
-      driver: json-file
-        max-file: "2"
-        max-size: 10m
+    logging: *json-logging
 
   nginx-docker-gen:
     restart: unless-stopped
-    logging:
-      driver: json-file
-        max-file: "2"
-        max-size: 10m
+    logging: *json-logging
 
   # Database used for local development
   mysql:
@@ -61,10 +50,7 @@ services:
       MYSQL_PORT: ${MYSQL_PORT:-3306}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-terrible-root-password-which-should-be-changed}  # yamllint disable-line rule:line-length
       MYSQL_USER: ${MYSQL_USER:-freezing}
-    logging:
-      driver: json-file
-        max-file: "2"
-        max-size: 10m
+    logging: *json-logging
 
   #### Freezing Saddles containers
 
@@ -82,20 +68,14 @@ services:
     depends_on:
       - beanstalkd
       - mysql
-    logging:
-      driver: json-file
-        max-file: "2"
-        max-size: 10m
+    logging: *json-logging
 
   freezing-nq:
     image: ${FREEZING_NQ_IMAGE:-freezingsaddles/freezing-nq:latest}
     restart: unless-stopped
     depends_on:
       - beanstalkd
-    logging:
-      driver: json-file
-        max-file: "2"
-        max-size: 10m
+    logging: *json-logging
 
   freezing-web:
     image: ${FREEZING_WEB_IMAGE:-freezingsaddles/freezing-web:latest}
@@ -124,7 +104,4 @@ services:
       TEAMS: ${TEAMS}
       TIMEZONE: ${TIMEZONE:-America/New_York}
       VIRTUAL_HOST: ${FREEZING_WEB_FQDN}
-    logging:
-      driver: json-file
-        max-file: "2"
-        max-size: 10m
+    logging: *json-logging

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,4 @@
 ---
-version: '3'
-
 volumes:
   freezing-data:
     external: true
@@ -10,9 +8,6 @@ services:
   #### Stock containers
 
   datadog:
-    restart: unless-stopped
-
-  logspout:
     restart: unless-stopped
 
   beanstalkd:
@@ -57,9 +52,9 @@ services:
       BEANSTALKD_PORT: ${BEANSTALKD_PORT:-11300}
       MYSQL_HOST: ${MYSQL_HOST:-mysql}
       MYSQL_PORT: ${MYSQL_HOST:-3306}
-        #SQLALCHEMY_SILENCE_UBER_WARNING: ${SQLALCHEMY_SILENCE_UBER_WARNING:-0}
+      SQLALCHEMY_SILENCE_UBER_WARNING: ${SQLALCHEMY_SILENCE_UBER_WARNING:-false}
       SQLALCHEMY_URL: ${SQLALCHEMY_URL}
-      SQLALCHEMY_WARN_20: ${SQLALCHEMY_WARN_20:-1}
+      SQLALCHEMY_WARN_20: ${SQLALCHEMY_WARN_20:-true}
     depends_on:
       - beanstalkd
       - mysql
@@ -88,7 +83,7 @@ services:
       MAIN_TEAM: ${MAIN_TEAM}
       OBSERVER_TEAMS: ${OBSERVER_TEAMS}
       SECRET_KEY: ${SECRET_KEY}
-        #SQLALCHEMY_SILENCE_UBER_WARNING: ${SQLALCHEMY_SILENCE_UBER_WARNING:-0}
+      SQLALCHEMY_SILENCE_UBER_WARNING: ${SQLALCHEMY_SILENCE_UBER_WARNING:-false}
       SQLALCHEMY_URL: ${SQLALCHEMY_URL}
       SQLALCHEMY_WARN_20: ${SQLALCHEMY_WARN_20:-1}
       START_DATE: ${START_DATE}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,18 +9,38 @@ services:
 
   datadog:
     restart: unless-stopped
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m
 
   beanstalkd:
     restart: unless-stopped
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m
 
   nginx:
     restart: unless-stopped
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m
 
   nginx-letsencrypt:
     restart: unless-stopped
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m
 
   nginx-docker-gen:
     restart: unless-stopped
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m
 
   # Database used for local development
   mysql:
@@ -41,6 +61,10 @@ services:
       MYSQL_PORT: ${MYSQL_PORT:-3306}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-terrible-root-password-which-should-be-changed}  # yamllint disable-line rule:line-length
       MYSQL_USER: ${MYSQL_USER:-freezing}
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m
 
   #### Freezing Saddles containers
 
@@ -58,12 +82,20 @@ services:
     depends_on:
       - beanstalkd
       - mysql
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m
 
   freezing-nq:
     image: ${FREEZING_NQ_IMAGE:-freezingsaddles/freezing-nq:latest}
     restart: unless-stopped
     depends_on:
       - beanstalkd
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m
 
   freezing-web:
     image: ${FREEZING_WEB_IMAGE:-freezingsaddles/freezing-web:latest}
@@ -92,3 +124,7 @@ services:
       TEAMS: ${TEAMS}
       TIMEZONE: ${TIMEZONE:-America/New_York}
       VIRTUAL_HOST: ${FREEZING_WEB_FQDN}
+    logging:
+      driver: json-file
+        max-file: "2"
+        max-size: 10m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,11 +68,6 @@ services:
     labels:
       - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"
     restart: unless-stopped
-      #logging:
-      #driver: json-file
-      #options:
-      #  max-file: "2"
-      #  max-size: 10m
     logging:
       driver: awslogs
       options:
@@ -83,6 +78,7 @@ services:
     # Version 2.3 is the last compatible version,
     # sha256:04b98015574addfba886023892f5e0ed28c012e1e72b8b43079e006f7e2c54d0
     # specifically.
+    # TODO: fix this https://github.com/freezingsaddles/freezing-compose/issues/32
     image: jrcs/letsencrypt-nginx-proxy-companion:2.3
     container_name: nginx-letsencrypt
     hostname: nginx-letsencrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     # sha256:04b98015574addfba886023892f5e0ed28c012e1e72b8b43079e006f7e2c54d0
     # specifically.
     # TODO: fix this with:
-    # https://github.com/freezingsaddles/freezing-compose/issues/32  
+    # https://github.com/freezingsaddles/freezing-compose/issues/32
     image: jrcs/letsencrypt-nginx-proxy-companion:2.3
     container_name: nginx-letsencrypt
     hostname: nginx-letsencrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,8 @@ services:
     # Version 2.3 is the last compatible version,
     # sha256:04b98015574addfba886023892f5e0ed28c012e1e72b8b43079e006f7e2c54d0
     # specifically.
-    # TODO: fix this https://github.com/freezingsaddles/freezing-compose/issues/32
+    # TODO: fix this with:
+    # https://github.com/freezingsaddles/freezing-compose/issues/32  
     image: jrcs/letsencrypt-nginx-proxy-companion:2.3
     container_name: nginx-letsencrypt
     hostname: nginx-letsencrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,24 +35,10 @@ services:
       SD_BACKEND: docker
     restart: unless-stopped
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
-
-  logspout:
-    image: mdsol/logspout
-    hostname: logspout
-    container_name: logspout
-    command: "${SYSLOG_ENDPOINT}"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    restart: unless-stopped
-    logging:
-      driver: json-file
-      options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: dd-agent
 
   beanstalkd:
     build: ./docker-beanstalkd
@@ -62,10 +48,10 @@ services:
       - beanstalkd-data:/data
     restart: unless-stopped
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: beanstalkd
 
   nginx:
     image: nginx:stable
@@ -82,11 +68,16 @@ services:
     labels:
       - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"
     restart: unless-stopped
+      #logging:
+      #driver: json-file
+      #options:
+      #  max-file: "2"
+      #  max-size: 10m
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: nginx
 
   nginx-letsencrypt:
     # Version 2.3 is the last compatible version,
@@ -106,10 +97,10 @@ services:
       - 'nginx-webroot:/usr/share/nginx/html'
     restart: unless-stopped
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: nginx-letsencrypt
 
   nginx-docker-gen:
     image: jwilder/docker-gen
@@ -127,10 +118,10 @@ services:
       - "com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen"
     restart: unless-stopped
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: nginx-docker-gen
 
   # ----------------------------------------------------------------------------
   # Application Containers
@@ -168,10 +159,10 @@ services:
       - ./sync-data:/data
     restart: unless-stopped
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: freezing-sync
 
   freezing-nq:
     image: freezingsaddles/freezing-nq:${FREEZING_NQ_TAG:-latest}
@@ -188,10 +179,10 @@ services:
       VIRTUAL_HOST: ${FREEZING_NQ_FQDN}
     restart: unless-stopped
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: freezing-nq
     depends_on:
       - beanstalkd
 
@@ -222,10 +213,10 @@ services:
       VIRTUAL_HOST: ${FREEZING_WEB_FQDN}
     restart: unless-stopped
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: freezing-web
 
   wordpress:
     image: wordpress:5.8.2
@@ -242,7 +233,7 @@ services:
       WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD}
       WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
     logging:
-      driver: json-file
+      driver: awslogs
       options:
-        max-file: "2"
-        max-size: 10m
+        awslogs-group: logspout
+        awslogs-stream: wordpress


### PR DESCRIPTION
logspout was not actually collecting any nginx logs, ugh.

So let's ureuse the `logspout` stream and log groups that were in place,
but use the awslogs driver directly instead. It seems to work at least
as well as logspout ever did...

Relates to #18
