### PR TITLE
fix bind interface

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -86,6 +86,7 @@ services:
     ports:
       - 8000:8000
     environment:
+      BIND_INTERFACE: "0.0.0.0"
       COMPETITION_TITLE: ${COMPETITION_TITLE}
       DEBUG: ${DEBUG}
       END_DATE: ${END_DATE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,6 +193,7 @@ services:
     depends_on:
       - beanstalkd
     environment:
+      BIND_INTERFACE: "0.0.0.0"
       COMPETITION_TITLE: ${COMPETITION_TITLE}
       DEBUG: ${DEBUG}
       END_DATE: ${END_DATE}


### PR DESCRIPTION
This is the interface bind directive for the freezing-web container on the inside, which had been hardcoded to `0.0.0.0` in the source code. Locking it down with a default of `127.0.0.1` in [Add bandit security scanner #290](https://github.com/freezingsaddles/freezing-web/pull/290) means we need to be explicit about setting this in the docker compose file.
