### PR TITLE
rename /data to /cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,7 @@ services:
       TIMEZONE: ${TIMEZONE:-America/New_York}
       VIRTUAL_HOST: ${FREEZING_WEB_FQDN}
     volumes:
-      - ./web-data:/data
+      - ./web-cache:/cache
     restart: always
     logging:
       driver: awslogs


### PR DESCRIPTION
Having this mapped on `/data` was disabling generic leaderboards.