### PR TITLE
Use tmpfs for freezing-web cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,11 @@ services:
       TIMEZONE: ${TIMEZONE:-America/New_York}
       VIRTUAL_HOST: ${FREEZING_WEB_FQDN}
     volumes:
-      - ./web-cache:/cache
+      - type: tmpfs
+        target: /cache
+        tmpfs:
+          size: 100M
+          mode: 1777
     restart: always
     logging:
       driver: awslogs


### PR DESCRIPTION
This avoids permission problems since freezing-web runs as UID 100.

It also dumps the cache on every restart of the service, which is fine
for this sort of cache anyway.
